### PR TITLE
Package.json improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "description": "",
   "main": "server.js",
   "scripts": {
+    "start": "gulp serve",
+    "postinstall": "bower install",
     "serve": "gulp serve",
     "build": "metalsmith"
   },
@@ -41,6 +43,7 @@
     "metalsmith-static": "0.0.5"
   },
   "devDependencies": {
+    "bower": "^1.7.x",
     "gulp": "^3.9.0",
     "gulp-run": "^1.6.12",
     "st": "^1.1.0"


### PR DESCRIPTION
This will allow for people to simply do `npm install` and `npm start` to run this locally, which is the standard now. It also means you don't need to require any other things be installed globally to the PATH of other's machines.