### PR TITLE
fix insecure request to google fonts

### DIFF
--- a/templates/partials/head.hbs
+++ b/templates/partials/head.hbs
@@ -12,7 +12,7 @@
 <!-- stylesheets -->
 <link href="/lib/normalize.css/normalize.css" rel="stylesheet" type="text/css">
 <link href="/css/style.css" rel="stylesheet" type="text/css">
-<link href='http://fonts.googleapis.com/css?family=Open+Sans:400,700,600' rel='stylesheet' type='text/css'>
+<link href='//fonts.googleapis.com/css?family=Open+Sans:400,700,600' rel='stylesheet' type='text/css'>
 <!-- scripts -->
 <script src="/lib/react/react.js"></script>
 <script src="/lib/react/react-dom.js"></script>


### PR DESCRIPTION
Replaced hard-coded `http://` with barely `//` to make browser
automatically request secured resource when accessing via `https:`.