### PR TITLE
Update site so the project doesnt appear dead

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -14,5 +14,5 @@
         }
     ],
     "UA": "UA-58514248-1",
-    "latest_new": "<a href='/blog/whats-new-in-0.13/'>What's New in 0.13 and Later</a>"
+    "latest_new": ""
 }

--- a/templates/partials/footer.hbs
+++ b/templates/partials/footer.hbs
@@ -16,7 +16,7 @@
         <a href="{{{config.links.twitter}}}">Twitter</a>
     </div>
     <div class="bottom">
-        <div class="left">Copyright &copy; 2015-2016 NW.js community</div>
+        <div class="left">Copyright &copy; 2015-2018 NW.js community</div>
         <div class="right">Web hosting sponsored by <a href="https://www.privateinternetaccess.com/">PIA</a></div>
     </div>
 </footer>


### PR DESCRIPTION
At first glance I thought this project was dead because of these two reasons:

- Below the download buttons I saw and read v0.13 and remembered it being v0.12 years ago. This PR removes this link.
- I then looked at copyright year which was out of date. This PR updates the latest copyright year.

I see the website needs an update but I think these two fixes should be uploaded sooner than later.