### PR TITLE
Add Discord link

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -5,7 +5,8 @@
         "download": "https://dl.nwjs.io",
         "twitter": "https://twitter.com/nw_js",
         "mailing_list": "https://groups.google.com/forum/#!forum/nwjs-general",
-        "gitter": "https://gitter.im/nwjs/nw.js"
+        "gitter": "https://gitter.im/nwjs/nw.js",
+        "discord": "https://discord.gg/tyx267vKRH"
     },
     "feeds": [
         {

--- a/templates/partials/footer.hbs
+++ b/templates/partials/footer.hbs
@@ -9,6 +9,7 @@
         <h2>Community</h2>
         <a href="{{{config.links.mailing_list}}}">Mailing List</a>
         <a href="{{{config.links.gitter}}}">Chat on Gitter</a>
+        <a href="{{{config.links.discord}}}">Chat on Discord</a>
     </div>
     <div class="column">
         <h2>Connect</h2>


### PR DESCRIPTION
Most of the JS community is on Discord (React, Vue, etc). This will be a more convenient place for them. The gitter can also stay up.