### PR TITLE
Add `arm64` to 0.77 version info

### DIFF
--- a/src/versions.json
+++ b/src/versions.json
@@ -6,7 +6,7 @@
         {
             "version": "v0.77.0",
             "date": "2023/06/05",
-            "files": ["win-x64", "win-ia32", "linux-x64", "linux-ia32", "osx-x64"],
+            "files": ["win-x64", "win-ia32", "linux-x64", "linux-ia32", "osx-x64", "osx-arm64"],
             "flavors": ["normal", "sdk"],
             "components": {
                 "node": "20.1.0",


### PR DESCRIPTION
This will allow `nw-builder` to download the osx arm64 version. `nw-builder` uses the `versions.json` file to parse and download valid NW.js binaries.

cc @rogerwang